### PR TITLE
feat: improve accessibility of hero video

### DIFF
--- a/src/components/landing/Hero.js
+++ b/src/components/landing/Hero.js
@@ -36,7 +36,19 @@ const Hero = ({ onPrimaryClick }) => {
               boxShadow: theme.shadows[8],
               background: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)'
             }}>
-              <Box component="video" autoPlay loop muted playsInline preload="auto" poster="/video-poster.jpg" controls={false} style={{ width: '100%', height: 'auto', display: 'block', pointerEvents: 'none' }}>
+              <Box
+                component="video"
+                aria-label="Product demonstration video"
+                autoPlay
+                loop
+                muted
+                playsInline
+                preload="auto"
+                poster="/video-poster.jpg"
+                controls={false}
+                style={{ width: '100%', height: 'auto', display: 'block', pointerEvents: 'none' }}
+              >
+                {/* Future enhancement: add captions or transcript for audio content */}
                 <source src="/Product Launch Video_compressed.mp4" type="video/mp4" />
                 <source src="/Product Launch Video.mp4" type="video/mp4" />
               </Box>


### PR DESCRIPTION
## Summary
- add aria-label to hero video for accessibility
- note future enhancement for captions or transcript

## Testing
- `CI=true npm test -- --passWithNoTests`
- `CI=true npm run build` (warnings: no-unused-vars in blog pages)


------
https://chatgpt.com/codex/tasks/task_b_689c7988ffe0832dbaf5bbaa04902c0e