### PR TITLE
feat: improve landing page responsiveness and accessibility

### DIFF
--- a/src/components/NewLandingPage.css
+++ b/src/components/NewLandingPage.css
@@ -65,6 +65,11 @@ body {
   box-shadow: 0 0 20px rgba(0, 191, 255, 0.5);
 }
 
+.primary-button:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 2px;
+}
+
 .secondary-button {
   background-color: transparent;
   color: #00bfff;
@@ -73,6 +78,29 @@ body {
 
 .secondary-button:hover {
   background-color: rgba(0, 191, 255, 0.1);
+}
+
+.secondary-button:focus-visible {
+  outline: 3px solid #00bfff;
+  outline-offset: 2px;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .hero-section h1 {
+    font-size: 2.5rem;
+  }
+
+  .cta-buttons {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-section h1 {
+    font-size: 2rem;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- add focus-visible outlines for primary and secondary CTA buttons
- stack CTA buttons vertically and scale hero heading on narrow screens

## Testing
- `node - <<'NODE' ...` *(script verifying responsive CSS)*
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_689c7987f134832d9ff213d915581530