### PR TITLE
Add circular loader to landing page hero

### DIFF
--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -24,7 +24,8 @@ import {
   useMediaQuery,
   useTheme,
   Tooltip,
-  Link
+  Link,
+  CircularProgress
 } from '@mui/material';
 import {
   SecurityOutlined as SecurityIcon,
@@ -340,7 +341,13 @@ const LandingPage = () => {
       </Helmet>
 
       {/* New Hero Section */}
-      <Suspense fallback={<Box sx={{ height: 320 }} />}> 
+      <Suspense
+        fallback={
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 320 }}>
+            <CircularProgress />
+          </Box>
+        }
+      >
         <Hero onPrimaryClick={handleGetStartedClick} />
       </Suspense>
 


### PR DESCRIPTION
## Summary
- replace placeholder Box with centered CircularProgress while Hero component loads
- import CircularProgress to support new fallback loader

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689c798655e4832d94040a71329f8393