### PR TITLE
Add accessibility label for drawer close button

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -155,7 +155,7 @@ const Layout = ({ children, showAuthButtons = false, maxWidth = 'lg' }) => {
         <Typography variant="h6" component="div">
           Lease Shield AI
         </Typography>
-        <IconButton onClick={handleDrawerToggle}>
+        <IconButton onClick={handleDrawerToggle} aria-label="Close navigation menu">
           <ChevronRight />
         </IconButton>
       </Box>


### PR DESCRIPTION
## Summary
- add aria-label to drawer close IconButton in layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689c79853fa8832d9b1784a22c00d1c5