### PR TITLE
fix: remove duplicate React import

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,6 @@ import Alert from '@mui/material/Alert';
 import { getApiBaseUrl } from './utils/api';
 
 // Pages
-import React from 'react';
 import Layout from './components/Layout';
 import { ColorModeContext } from './context/ColorModeContext';
 import RouteErrorBoundary from './components/RouteErrorBoundary';


### PR DESCRIPTION
## Summary
- remove duplicate React import from App.js that caused build failure

## Testing
- `npm test -- --watchAll=false`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_b_689c8c36e6f8832d8b24895d90a249bb