### PR TITLE
fix: reorder imports before debugLog

### DIFF
--- a/src/pages/RealEstateAgentPage.js
+++ b/src/pages/RealEstateAgentPage.js
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useEffect, useMemo, lazy, Suspense } from
 import { useDropzone } from 'react-dropzone';
 import { auth } from '../firebase/config'; // Import Firebase auth
 import { getApiBaseUrl } from '../utils/api';
-const debugLog = (...args) => { if (process.env.NODE_ENV === 'development') console.log(...args); };
 import {
   Box,
   Typography,
@@ -22,11 +21,13 @@ import {
   Alert,
   FormGroup
 } from '@mui/material';
-import { 
-    FileUpload as FileUploadIcon, 
-    Clear as ClearIcon, 
+import {
+    FileUpload as FileUploadIcon,
+    Clear as ClearIcon,
     Description as DescriptionIcon // For non-image files
 } from '@mui/icons-material';
+
+const debugLog = (...args) => { if (process.env.NODE_ENV === 'development') console.log(...args); };
 
 // Helper function to format currency (optional, but nice)
 const formatCurrency = (value) => {

--- a/src/pages/TrialPage.js
+++ b/src/pages/TrialPage.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-
-const debugLog = (...args) => { if (process.env.NODE_ENV === 'development') console.log(...args); };
 import { Box, Typography, Button, Container, Paper, Grid, Card, CardContent, CardActions, List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+
+const debugLog = (...args) => { if (process.env.NODE_ENV === 'development') console.log(...args); };
 
 // Define Plan Details (could be moved to a config file later)
 const plans = [


### PR DESCRIPTION
## Summary
- reorder imports above debugLog to satisfy eslint import/first rule in agent and trial pages

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689c8f249814832d9562015bd67416fd