### PR TITLE
feat: add AI chat module to landing page

### DIFF
--- a/src/components/BentoFeaturesGrid.js
+++ b/src/components/BentoFeaturesGrid.js
@@ -22,6 +22,7 @@ import {
   Speed as SpeedIcon,
   TrendingUp as TrendingUpIcon,
   Star as StarIcon,
+  Chat as ChatIcon,
 } from '@mui/icons-material';
 import { BentoGridItem, GlassmorphismCard } from './InteractiveComponents';
 
@@ -81,6 +82,16 @@ const BentoFeaturesGrid = () => {
       stats: 'Instant Reports',
       features: ['Issue Detection', 'Cost Estimation', 'Annotated Reports'],
       color: '#42a5f5'
+    },
+    {
+      id: 'ai-chat',
+      title: 'AI Chat',
+      description: 'Get instant answers to your lease questions with our conversational assistant.',
+      icon: <ChatIcon sx={{ fontSize: 40 }} />,
+      link: '/chat',
+      stats: '24/7 Assistant',
+      features: ['Instant Answers', 'Lease Guidance'],
+      color: '#ab47bc'
     },
   ];
 

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -63,7 +63,8 @@ import {
   BuildOutlined as BuildIcon,
   AnalyticsOutlined as AnalyticsIcon,
   PersonSearch as PersonSearchIcon,
-  Upcoming as UpcomingIcon
+  Upcoming as UpcomingIcon,
+  Chat as ChatIcon
 } from '@mui/icons-material';
 import BentoFeaturesGrid from '../components/BentoFeaturesGrid';
 const InteractiveClauseAnalyzer = React.lazy(() => import('../components/InteractiveClauseAnalyzer'));
@@ -153,6 +154,12 @@ const LandingPage = () => {
       description: "Upload property photos (walls, fixtures, roof) to detect issues and estimate repair costs—instantly producing annotated reports and budgets.",
       icon: <CameraAltIcon sx={{ fontSize: 40 }} color="primary" />,
       link: "/photo-inspection"
+    },
+    {
+      title: "AI Chat",
+      description: "Get instant answers to your lease questions with our conversational assistant.",
+      icon: <ChatIcon sx={{ fontSize: 40 }} color="primary" />,
+      link: "/chat"
     }
   ];
 


### PR DESCRIPTION
## Summary
- add AI Chat module to feature grid
- include AI Chat in landing page module list

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c95937130832dad1c8de52b4d5dd8