### PR TITLE
Add Docker-based dev environment with make target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 REACT_APP_FIREBASE_API_KEY=your_firebase_api_key
-REACT_APP_API_URL=https://lease-shield-backend.onrender.com
+REACT_APP_API_URL=http://localhost:8081
+GEMINI_API_KEY_1=your_gemini_api_key
+ADMIN_EMAIL=admin@example.com
 MAXELPAY_WEBHOOK_SECRET=your_maxelpay_webhook_secret

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: dev
+
+dev:
+	docker compose up --build

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ graph LR
    ```
 2. Start everything with one command:
    ```bash
-   docker compose up
+   make dev
    ```
 3. Call the Hello API once the containers are running:
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,30 @@ services:
   backend:
     build: ./backend
     ports:
-      - "8081:8081"
+      - "8081:8080"
     environment:
       - GEMINI_API_KEY_1=${GEMINI_API_KEY_1}
       - ADMIN_EMAIL=${ADMIN_EMAIL}
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  frontend:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+    command: sh -c "npm install && npm start"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5


### PR DESCRIPTION
## Summary
- add Makefile with `dev` target to boot stack via Docker Compose
- extend `.env.example` and docker-compose.yml for backend and frontend with health checks
- document using `make dev` in README

## Testing
- `CI=true npm test --silent`
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_689ce7340e48832d93c53cd8deb8f2f1